### PR TITLE
Set the client and cache on boot(_ drop:)

### DIFF
--- a/Sources/NStack/Application.swift
+++ b/Sources/NStack/Application.swift
@@ -2,7 +2,9 @@ import Vapor
 import Cache
 public struct Application{
     // Basic
-    let cache: CacheProtocol
+    var cache: CacheProtocol? {
+        return connectionManager.cache
+    }
     let connectionManager: ConnectionManager
     let applicationConfig: ApplicationConfig
     let nStackConfig: NStackConfig
@@ -16,8 +18,7 @@ public struct Application{
     let restKey: String
     let masterKey: String
     
-    init(cache: CacheProtocol, connectionManager: ConnectionManager, applicationConfig: ApplicationConfig, nStackConfig: NStackConfig){
-        self.cache = cache
+    init(connectionManager: ConnectionManager, applicationConfig: ApplicationConfig, nStackConfig: NStackConfig){
         self.connectionManager = connectionManager
         self.applicationConfig = applicationConfig
         self.nStackConfig = nStackConfig
@@ -28,5 +29,3 @@ public struct Application{
         self.masterKey = applicationConfig.masterKey
     }
 }
-
-

--- a/Sources/NStack/Configs/NStackConfig.swift
+++ b/Sources/NStack/Configs/NStackConfig.swift
@@ -26,7 +26,7 @@ public struct NStackConfig {
         }
     }
     
-    init(config: Config) throws {
+    public init(config: Config) throws {
         guard let config: Config = config["nstack"] else {
             throw ConfigError.nstack.error
         }

--- a/Sources/NStack/ConnectionManager.swift
+++ b/Sources/NStack/ConnectionManager.swift
@@ -4,8 +4,8 @@ import Vapor
 
 public final class ConnectionManager {
     static let baseUrl = "https://nstack.io/api/v1/"
-    internal var client: ClientProtocol?
     internal var cache: CacheProtocol?
+    internal var client: ClientProtocol?
     private let translateConfig: TranslateConfig
 
     init(translateConfig: TranslateConfig) throws {

--- a/Sources/NStack/NStack.swift
+++ b/Sources/NStack/NStack.swift
@@ -1,6 +1,5 @@
 import Cache
 import Foundation
-import TLS
 import Vapor
 
 public final class NStack {
@@ -33,24 +32,6 @@ public final class NStack {
         
         // Set picked application
         self.defaultApplication = try setApplication(name: config.defaultApplication)
-    }
-    
-    public convenience init(
-        config: Vapor.Config,
-        cache: CacheProtocol? = nil,
-        clientFactory: ClientFactoryProtocol? = nil
-    ) throws {
-        let nStackConfig = try NStackConfig(config: config)
-
-        let connectionManager = try ConnectionManager(translateConfig: nStackConfig.translate)
-        connectionManager.cache = cache
-        connectionManager.client = try clientFactory?.makeClient(
-            hostname: ConnectionManager.baseUrl,
-            port: 443,
-            securityLayer: .tls(Context(.client))
-        )
-
-        try self.init(config: nStackConfig, connectionManager: connectionManager)
     }
     
     public func setApplication(name: String) throws -> Application {

--- a/Sources/NStack/NStack.swift
+++ b/Sources/NStack/NStack.swift
@@ -5,21 +5,19 @@ import Cache
 public final class NStack {
     public let connectionManager: ConnectionManager
     public let config: NStackConfig
-    public let cache: CacheProtocol
     var defaultApplication: Application
     
     public let applications: [Application]
     public var application: Application
     
-    public init(config: NStackConfig, connectionManager: ConnectionManager, cache: CacheProtocol) throws {
+    public init(config: NStackConfig, connectionManager: ConnectionManager) throws {
         self.config = config
         self.connectionManager = connectionManager
-        self.cache = cache
-        
+
         // Set applications
         var applications: [Application] = []
         for applicationConfig in self.config.applications {
-            applications.append(Application(cache: cache, connectionManager: connectionManager, applicationConfig: applicationConfig, nStackConfig: config))
+            applications.append(Application(connectionManager: connectionManager, applicationConfig: applicationConfig, nStackConfig: config))
         }
         
         self.applications = applications
@@ -38,10 +36,10 @@ public final class NStack {
     
     public convenience init(config: Config) throws {
         let nStackConfig = try NStackConfig(config: config)
-        let connectionManager = try ConnectionManager(translateConfig: nStackConfig.translate, clientFactory: config.resolveClient())
-        let cache = try config.resolveCache()
 
-        try self.init(config: nStackConfig, connectionManager: connectionManager, cache: cache)
+        let connectionManager = try ConnectionManager(translateConfig: nStackConfig.translate)
+
+        try self.init(config: nStackConfig, connectionManager: connectionManager)
     }
     
     public func setApplication(name: String) throws -> Application {
@@ -65,6 +63,4 @@ public final class NStack {
         
         return application
     }
-    
-    
 }

--- a/Sources/NStack/NStackProvider.swift
+++ b/Sources/NStack/NStackProvider.swift
@@ -1,27 +1,27 @@
-import TLS
 import Vapor
 
 public final class NStackProvider: Vapor.Provider {
     public static var repositoryName: String = "NStack"
 
-    let nstack: NStack
+    private let nStackConfig: NStackConfig
 
     public func boot(_ drop: Droplet) throws {
-        nstack.connectionManager.client = try drop.config.resolveClient()
-            .makeClient(
-                hostname: ConnectionManager.baseUrl,
-                port: 443,
-                securityLayer: .tls(Context(.client))
+        let connectionManager = try ConnectionManager(
+            cache: drop.cache,
+            clientFactory: drop.client,
+            nStackConfig: nStackConfig
         )
-        nstack.connectionManager.cache = try drop.config.resolveCache()
 
-        drop.nstack = nstack
+        drop.nstack = try NStack(
+            config: nStackConfig,
+            connectionManager: connectionManager
+        )
     }
 
-    public func boot(_ config: Vapor.Config) throws {}
+    public func boot(_ config: Config) throws {}
 
-    public init(config: Vapor.Config) throws {
-        nstack = try NStack(config: config)
+    public init(config: Config) throws {
+        nStackConfig = try NStackConfig(config: config)
     }
     
     public func beforeRun(_: Droplet) {}

--- a/Sources/NStack/NStackProvider.swift
+++ b/Sources/NStack/NStackProvider.swift
@@ -1,3 +1,4 @@
+import TLS
 import Vapor
 
 public final class NStackProvider: Vapor.Provider {
@@ -5,13 +6,21 @@ public final class NStackProvider: Vapor.Provider {
 
     let nstack: NStack
 
-    public func boot(_ drop: Droplet) {
+    public func boot(_ drop: Droplet) throws {
+        nstack.connectionManager.client = try drop.config.resolveClient()
+            .makeClient(
+                hostname: ConnectionManager.baseUrl,
+                port: 443,
+                securityLayer: .tls(Context(.client))
+        )
+        nstack.connectionManager.cache = try drop.config.resolveCache()
+
         drop.nstack = nstack
     }
 
-    public func boot(_ config: Config) throws {}
+    public func boot(_ config: Vapor.Config) throws {}
 
-    public init(config: Config) throws {
+    public init(config: Vapor.Config) throws {
         nstack = try NStack(config: config)
     }
     


### PR DESCRIPTION
Workaround for Client and Cache not being available at config time. Configure everything as before but set client and cache in boot(_ drop:) phase.