### PR TITLE
Add required droplet.json configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Create config `nstack.json`
     ]
 }
 ```
-Set client to foundation in `droplet.json`
+Make sure that client is set to foundation in `droplet.json` because the engine client does not properly support the required SSL connections.
 ```json
   ...
   "client": "foundation",

--- a/README.md
+++ b/README.md
@@ -42,7 +42,12 @@ Create config `nstack.json`
         }
     ]
 }
-
+```
+Set client to foundation in `droplet.json`
+```json
+  ...
+  "client": "foundation",
+  ...
 ```
 
 ## Getting started 🚀


### PR DESCRIPTION
Since this package wont work and throws an exception:
`Identifier: Sockets.SocketsError.ipAddressValidationFailed`
when not setting the **client** to **foundation** in `droplet.json` my suggestion is adding this required configuration to the readme. 😊