### PR TITLE
Guard that at least two arguments have been given.

### DIFF
--- a/Sources/NStack/Modules/Translate/Tags/TranslateTag.swift
+++ b/Sources/NStack/Modules/Translate/Tags/TranslateTag.swift
@@ -16,9 +16,8 @@ public final class TranslateTag: TagRenderer {
 
     public func render(tag: TagContext) throws -> Future<TemplateData> {
 
-        try tag.requireParameterCount(2)
-
         guard
+            tag.parameters.count >= 2,
             let section = tag.parameters[0].string,
             let key = tag.parameters[1].string
         else {


### PR DESCRIPTION
Currently the method will throw if we give a set of replacements strings, so in stead of using requireParameterCount() we we check that there is at least two arguments in the request, which reenables the option to provide replacement strings.