### PR TITLE
Feature/fix nstack leaftag

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add `NStack` to the Package dependencies:
 ```swift
 dependencies: [
     // ...,
-    .package(url: "https://github.com/nodes-vapor/nstack.git", .upToNextMinor(from: "3.0.0-beta"))
+    .package(url: "https://github.com/nodes-vapor/nstack.git", .upToNextMajor(from: "3.0.0-beta"))
 ]
 ```
 
@@ -76,7 +76,13 @@ If you plan on using the leaf tag (see below), make sure to use a synchronous ca
 
 In `configure.swift`:
 ```swift
-try services.register(NStackProvider<MemoryKeyedCache>(config: nstackConfig))
+// MARK: NStack
+try services.register(
+    NStackProvider(
+        config: nstackConfig,
+        cacheFactory: { container in try container.make(MemoryKeyedCache.self) }
+    )
+)
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add `NStack` to the Package dependencies:
 ```swift
 dependencies: [
     // ...,
-    .package(url: "https://github.com/nodes-vapor/nstack.git", .upToNextMinor(from: "3.0.0"))
+    .package(url: "https://github.com/nodes-vapor/nstack.git", .upToNextMinor(from: "3.0.0-beta"))
 ]
 ```
 
@@ -72,10 +72,11 @@ If you set `log` to `true` you will receive helpful logs in case anything goes w
 ### Adding the Service
 
 Instantiate and register `NStackProvider` with config created in the previous step.
+If you plan on using the leaf tag (see below), make sure to use a synchronous cache, such as `MemoryKeyedCache` (and not `RedisCache`); otherwise it might break your leaf templates, see https://github.com/vapor/leaf/issues/134
 
 In `configure.swift`:
 ```swift
-try services.register(NStackProvider(config: nstackConfig))
+try services.register(NStackProvider<MemoryKeyedCache>(config: nstackConfig))
 ```
 
 ## Usage
@@ -161,6 +162,14 @@ NStack comes with a built-in Leaf tag. The tag yields a translated string or the
 
 // Get translation for camelCasedSection.camelCasedKey and replace searchString1 with replaceString1 etc
 #nstack:translate("camelCasedSection", "camelCasedKey", "searchString1", "replaceString1", "searchString2", "replaceString2", ...)
+```
+
+*IMPORTANT:* Due to a bug in leaf you have to make sure that the translations are already loaded and available synchronously when rendering the view. This can be achieved by using the `NStackPreloadMiddleware` on the routes for your views:
+
+
+```swift
+let nstackPreloadMiddleware = try container.make(NStackPreloadMiddleware.self)
+let unprotectedBackend = router.grouped(nstackPreloadMiddleware)
 ```
 
 Please note that the leaf tag always uses the **current application** with the **default translate config** that you have provided.

--- a/Sources/NStack/Middlewares/NStackPreloadMiddleware.swift
+++ b/Sources/NStack/Middlewares/NStackPreloadMiddleware.swift
@@ -1,0 +1,28 @@
+import Vapor
+
+public final class NStackPreloadMiddleware: Middleware {
+    
+    public func respond(
+        to request: Request,
+        chainingTo next: Responder
+    ) throws -> Future<Response> {
+        
+        guard let nstack = try? request.make(NStack.self) else {
+            try? request.make(NStackLogger.self).log("NStack has not been registered.")
+            return try next.respond(to: request)
+        }
+        
+        return try nstack.application.translate.preloadLocalization(on: request).flatMap { _ in
+            return try next.respond(to: request)
+        }.catchFlatMap { error in
+            try? request.make(NStackLogger.self).log("NStack error: \(error)")
+            return try next.respond(to: request)
+        }
+    }
+}
+
+extension NStackPreloadMiddleware: ServiceType {
+    public static func makeService(for container: Container) throws -> NStackPreloadMiddleware {
+        return .init()
+    }
+}

--- a/Sources/NStack/Middlewares/NStackPreloadMiddleware.swift
+++ b/Sources/NStack/Middlewares/NStackPreloadMiddleware.swift
@@ -8,7 +8,7 @@ public final class NStackPreloadMiddleware: Middleware {
     ) throws -> Future<Response> {
         
         guard let nstack = try? request.make(NStack.self) else {
-            try? request.make(NStackLogger.self).log("NStack has not been registered.")
+            print("NStack has not been registered.")
             return try next.respond(to: request)
         }
         

--- a/Sources/NStack/Modules/Translate/Controller/TranslateController.swift
+++ b/Sources/NStack/Modules/Translate/Controller/TranslateController.swift
@@ -92,6 +92,18 @@ public final class TranslateController {
         }
     }
 
+    public final func preloadLocalization(
+        on worker: Container,
+        platform: Platform? = nil,
+        language: String? = nil
+    ) throws -> Future<Void> {
+        
+        let platform = platform ?? self.config.defaultPlatform
+        let language = language ?? self.config.defaultLanguage
+        
+        return try fetchLocalization(on: worker, platform: platform, language: language).transform(to: ())
+    }
+    
     private final func fetchLocalization(
         on worker: Container,
         platform: Platform,

--- a/Sources/NStack/Modules/Translate/Controller/TranslateController.swift
+++ b/Sources/NStack/Modules/Translate/Controller/TranslateController.swift
@@ -92,7 +92,7 @@ public final class TranslateController {
         }
     }
 
-    public final func preloadLocalization(
+    internal final func preloadLocalization(
         on worker: Container,
         platform: Platform? = nil,
         language: String? = nil

--- a/Sources/NStack/NStack.swift
+++ b/Sources/NStack/NStack.swift
@@ -41,7 +41,10 @@ public final class NStack {
         self.defaultApplication = try getApplication(name: config.defaultApplicationName)
     }
     
-    internal convenience init(on container: Container, cache: KeyedCache? = nil) throws {
+    internal convenience init(
+        on container: Container,
+        cacheFactory: @escaping ((Container) throws -> KeyedCache) = { container in try container.make() }
+    ) throws {
         
         let config = try container.make(NStack.Config.self)
         let client = try container.make(Client.self)
@@ -49,7 +52,7 @@ public final class NStack {
         let connectionManager = try ConnectionManager(
             client: client,
             config: config,
-            cache: cache ?? container.make(KeyedCache.self)
+            cache: cacheFactory(container)
         )
         
         try self.init(
@@ -79,7 +82,6 @@ public final class NStack {
 extension NStack: ServiceType {
 
     public static func makeService(for worker: Container) throws -> Self {
-        
         return try self.init(on: worker)
     }
 }


### PR DESCRIPTION
This PR works around the vapor leaf bug (vapor/leaf#134) by adding a middleware to preload content. 

As this issue would also appear with async caches, this PR also introduces an option to provide the `KeyedCache` that should be used specifically by NStack to allow you to use an async cache (e.g. `RedisCache`) for the rest of your project while having a sync cache (e.g. `MemoryKeyedCache`) for NStack.