### PR TITLE
Feature/deprecate master key

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ let nstackConfig = NStack.Config(
         Application.Config(
             name: "my app name",
             applicationId: "NEVER_PUT_API_IDS_IN_SOURCE_CODE",
-            restKey: "NEVER_PUT_API_KEYS_IN_SOURCE_CODE",
-            masterKey: "DEFINITELY_NEVER_EXPOSTE_THE_MASTER_KEY_IN_SOURCE_CODE"
+            restKey: "NEVER_PUT_API_KEYS_IN_SOURCE_CODE"
         )
     ],
     defaultTranslateConfig: TranslateController.Config(

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add `NStack` to the Package dependencies:
 ```swift
 dependencies: [
     // ...,
-    .package(url: "https://github.com/nodes-vapor/nstack.git", .upToNextMajor(from: "3.0.0-beta"))
+    .package(url: "https://github.com/nodes-vapor/nstack.git", .from(from: "3.0.0-beta"))
 ]
 ```
 
@@ -50,7 +50,7 @@ Create `NStack.Config` to configure `NStack`, your `Applications` as well as the
 ```swift
 let nstackConfig = NStack.Config(
     applicationConfigs: [
-        Application.Config.init(
+        Application.Config(
             name: "my app name",
             applicationId: "NEVER_PUT_API_IDS_IN_SOURCE_CODE",
             restKey: "NEVER_PUT_API_KEYS_IN_SOURCE_CODE",

--- a/Sources/NStack/Application+Config.swift
+++ b/Sources/NStack/Application+Config.swift
@@ -1,6 +1,6 @@
 public extension Application {
 
-    public struct Config: Codable {
+    struct Config: Codable {
 
         public let name: String
         public let applicationId: String

--- a/Sources/NStack/Application+Config.swift
+++ b/Sources/NStack/Application+Config.swift
@@ -5,8 +5,13 @@ public extension Application {
         public let name: String
         public let applicationId: String
         public let restKey: String
-        public let masterKey: String
 
+        @available(*, deprecated, message: "Master Key is not needed and should not be included.")
+        public var masterKey: String {
+            return ""
+        }
+
+        @available(*, deprecated, message: "Use of Master Key is deprecated. Use init without it instead.")
         public init(
             name: String,
             applicationId: String,
@@ -16,7 +21,16 @@ public extension Application {
             self.name = name
             self.applicationId = applicationId
             self.restKey = restKey
-            self.masterKey = masterKey
+        }
+
+        public init(
+            name: String,
+            applicationId: String,
+            restKey: String
+        ) {
+            self.name = name
+            self.applicationId = applicationId
+            self.restKey = restKey
         }
     }
 }

--- a/Sources/NStack/Application.swift
+++ b/Sources/NStack/Application.swift
@@ -2,16 +2,16 @@ import Vapor
 
 public struct Application {
 
-    internal var connectionManager: ConnectionManager
-    internal let config: NStack.Config
-    internal let applicationConfig: Application.Config
-    internal let translateConfig: Translate.Config?
+    var connectionManager: ConnectionManager
+    let config: NStack.Config
+    let applicationConfig: Application.Config
+    let translateConfig: Translate.Config?
 
-    internal var name: String { get { return applicationConfig.name }}
-    internal var applicationId: String { get { return applicationConfig.applicationId }}
-    internal var restKey: String { get { return applicationConfig.restKey }}
+    var name: String { return applicationConfig.name }
+    var applicationId: String { return applicationConfig.applicationId }
+    var restKey: String { return applicationConfig.restKey }
 
-    internal var cache: KeyedCache { get { return connectionManager.cache }}
+    var cache: KeyedCache { return connectionManager.cache }
     
     public lazy var translate: TranslateController = TranslateController(
         application: self,
@@ -20,7 +20,7 @@ public struct Application {
 
     public private(set) lazy var version = VersionController(application: self)
 
-    internal init(
+    init(
         connectionManager: ConnectionManager,
         config: NStack.Config,
         applicationConfig: Application.Config,

--- a/Sources/NStack/Application.swift
+++ b/Sources/NStack/Application.swift
@@ -10,7 +10,6 @@ public struct Application {
     internal var name: String { get { return applicationConfig.name }}
     internal var applicationId: String { get { return applicationConfig.applicationId }}
     internal var restKey: String { get { return applicationConfig.restKey }}
-    internal var masterKey: String { get { return applicationConfig.masterKey }}
 
     internal var cache: KeyedCache { get { return connectionManager.cache }}
     

--- a/Sources/NStack/ConnectionManager.swift
+++ b/Sources/NStack/ConnectionManager.swift
@@ -1,13 +1,13 @@
 import HTTP
 import Vapor
 
-internal final class ConnectionManager {
+final class ConnectionManager {
 
-    internal let client: Client
-    internal let config: NStack.Config
-    internal let cache: KeyedCache
+    let client: Client
+    let config: NStack.Config
+    let cache: KeyedCache
 
-    internal init(
+    init(
         client: Client,
         config: NStack.Config,
         cache: KeyedCache
@@ -17,7 +17,7 @@ internal final class ConnectionManager {
         self.cache = cache
     }
     
-    internal func getTranslation(
+    func getTranslation(
         application: Application,
         platform: Translate.Platform,
         language: String

--- a/Sources/NStack/Modules/Translate/Controller/Translate+Config.swift
+++ b/Sources/NStack/Modules/Translate/Controller/Translate+Config.swift
@@ -2,7 +2,7 @@ import Vapor
 
 public extension Translate {
 
-    public struct Config: Codable {
+    struct Config: Codable {
 
         public let defaultPlatform: Translate.Platform
         public let defaultLanguage: String

--- a/Sources/NStack/Modules/Translate/Controller/TranslateController.swift
+++ b/Sources/NStack/Modules/Translate/Controller/TranslateController.swift
@@ -8,13 +8,13 @@ public final class TranslateController {
     var localizations: [String: Localization] = [:]
     var attempts: [String: TranslationAttempt] = [:]
 
-    internal var cache: KeyedCache { get { return self.application.cache }}
+    var cache: KeyedCache { return self.application.cache }
 
     public enum Platform: String, Codable {
         case backend, api, web, mobile
     }
 
-    internal init(application: Application, config: Translate.Config) {
+    init(application: Application, config: Translate.Config) {
         self.application = application
         self.config = config
     }
@@ -92,7 +92,7 @@ public final class TranslateController {
         }
     }
 
-    internal final func preloadLocalization(
+    final func preloadLocalization(
         on worker: Container,
         platform: Platform? = nil,
         language: String? = nil

--- a/Sources/NStack/Modules/Translate/Models/Localization+ResponseData.swift
+++ b/Sources/NStack/Modules/Translate/Models/Localization+ResponseData.swift
@@ -1,16 +1,16 @@
 extension Localization {
 
-    internal struct ResponseData: Codable {
+    struct ResponseData: Codable {
 
-        internal let translations: LocalizationFormat
-        internal let meta: Meta
+        let translations: LocalizationFormat
+        let meta: Meta
 
-        internal struct Meta: Codable {
+        struct Meta: Codable {
 
-            internal let language: Language
-            internal let acceptLanguage: String
+            let language: Language
+            let acceptLanguage: String
 
-            internal struct Language: Codable {
+            struct Language: Codable {
 
                 let id: Int
                 let name: String

--- a/Sources/NStack/Modules/Translate/Models/Localization.swift
+++ b/Sources/NStack/Modules/Translate/Models/Localization.swift
@@ -1,19 +1,19 @@
 import Vapor
 import Foundation
 
-internal struct Localization: Codable {
+struct Localization: Codable {
 
-    internal typealias Section = String
-    internal typealias Key = String
-    internal typealias Translation = String
-    internal typealias LocalizationFormat = [Section: [Key: Translation]]
+    typealias Section = String
+    typealias Key = String
+    typealias Translation = String
+    typealias LocalizationFormat = [Section: [Key: Translation]]
 
-    internal let translations: LocalizationFormat
-    internal let platform: Translate.Platform
-    internal let language: String
-    internal let date: Date
+    let translations: LocalizationFormat
+    let platform: Translate.Platform
+    let language: String
+    let date: Date
 
-    internal init(
+    init(
         responseData: ResponseData,
         platform: Translate.Platform,
         language: String
@@ -24,7 +24,7 @@ internal struct Localization: Codable {
         self.date = Date()
     }
 
-    internal func isOutdated(on worker: Container, _ cacheInMinutes: Int) -> Bool {
+    func isOutdated(on worker: Container, _ cacheInMinutes: Int) -> Bool {
 
         let cacheInSeconds: TimeInterval = Double(cacheInMinutes) * 60
         let expirationDate: Date = self.date.addingTimeInterval(cacheInSeconds)
@@ -33,7 +33,7 @@ internal struct Localization: Codable {
         return (expirationDate.compare(Date()) == .orderedAscending)
     }
 
-    internal func get(on worker: Container, section: Section, key: Key) -> Translation {
+    func get(on worker: Container, section: Section, key: Key) -> Translation {
 
         guard let translation = translations[section]?[key] else {
 
@@ -43,7 +43,7 @@ internal struct Localization: Codable {
         return translation
     }
 
-    internal func get(on worker: Container, section: Section) -> [Key: Translation] {
+    func get(on worker: Container, section: Section) -> [Key: Translation] {
 
         guard let sectionTranslations = translations[section] else {
 
@@ -53,11 +53,11 @@ internal struct Localization: Codable {
         return sectionTranslations
     }
 
-    internal static func fallback(section: Section, key: Key) -> Translation {
+    static func fallback(section: Section, key: Key) -> Translation {
         return section + "." + key
     }
 
-    internal static func fallback(section: Section) -> [Key: Translation] {
+    static func fallback(section: Section) -> [Key: Translation] {
         return [Key: Translation]()
     }
 }

--- a/Sources/NStack/Modules/Translate/Models/TranslationAttempt.swift
+++ b/Sources/NStack/Modules/Translate/Models/TranslationAttempt.swift
@@ -1,19 +1,19 @@
 import Vapor
 import Foundation
 
-internal class TranslationAttempt {
+final class TranslationAttempt {
 
     private var dates: [Date: Error] = [:]
 
-    internal init(error: Error) throws {
+    init(error: Error) throws {
         try append(error: error)
     }
 
-    internal func append(error: Error) throws {
+    func append(error: Error) throws {
         dates[Date()] = error
     }
 
-    internal func avoidFetchingAgain() -> Bool {
+    func avoidFetchingAgain() -> Bool {
 
         let datePreRetryPeriod = Date().addingTimeInterval(-3 * 60)
         let datePreNotFoundPeriod =  Date().addingTimeInterval(-5 * 60)

--- a/Sources/NStack/NStack+Config.swift
+++ b/Sources/NStack/NStack+Config.swift
@@ -2,7 +2,7 @@ import Vapor
 
 public extension NStack {
 
-    public struct Config: Service {
+    struct Config: Service {
 
         public let applicationConfigs: [Application.Config]
         public let defaultApplicationName: String

--- a/Sources/NStack/NStack.swift
+++ b/Sources/NStack/NStack.swift
@@ -8,12 +8,12 @@ public final class NStack {
 
     public var application: Application
 
-    internal let connectionManager: ConnectionManager
-    internal let config: NStack.Config
-    internal let applications: [Application]
-    internal var defaultApplication: Application
+    let connectionManager: ConnectionManager
+    let config: NStack.Config
+    let applications: [Application]
+    var defaultApplication: Application
     
-    internal init(
+    init(
         connectionManager: ConnectionManager,
         config: NStack.Config,
         translateConfig: Translate.Config? = nil
@@ -41,7 +41,7 @@ public final class NStack {
         self.defaultApplication = try getApplication(name: config.defaultApplicationName)
     }
     
-    internal convenience init(
+    convenience init(
         on container: Container,
         cacheFactory: @escaping ((Container) throws -> KeyedCache) = { container in try container.make() }
     ) throws {

--- a/Sources/NStack/NStackLogger.swift
+++ b/Sources/NStack/NStackLogger.swift
@@ -1,14 +1,14 @@
 import Vapor
 
-internal final class NStackLogger {
+final class NStackLogger {
 
-    internal let enabled: Bool
+    let enabled: Bool
 
-    internal init(enabled: Bool) {
+    init(enabled: Bool) {
         self.enabled = enabled
     }
 
-    internal func log(_ message: String) {
+    func log(_ message: String) {
         if enabled {
             debugPrint("[NStack] \(message)")
         }

--- a/Sources/NStack/NStackProvider.swift
+++ b/Sources/NStack/NStackProvider.swift
@@ -3,8 +3,8 @@ import Leaf
 
 public final class NStackProvider {
 
-    internal let config: NStack.Config
-    internal let cacheFactory: ((Container) throws -> KeyedCache)
+    let config: NStack.Config
+    let cacheFactory: ((Container) throws -> KeyedCache)
     
     public init(
         config: NStack.Config,

--- a/Sources/NStack/NStackProvider.swift
+++ b/Sources/NStack/NStackProvider.swift
@@ -37,7 +37,7 @@ extension NStackProvider: Provider {
 }
 
 public extension LeafTagConfig {
-    public mutating func useNStackLeafTags(_ container: Container) throws {
+    mutating func useNStackLeafTags(_ container: Container) throws {
         let nstack = try container.make(NStack.self)
         use(TranslateTag(nstack: nstack), as: "nstack:translate")
     }


### PR DESCRIPTION
- Deprecates use of master key (which was never needed anyway). This is the main focus of this PR.
- Fixes warnings for Swift 5
- Remove redundent `internal` and `public` access modifiers
- Make an internal class final