### PR TITLE
Prevent NStack from catching all response errors

### DIFF
--- a/Sources/NStack/Middlewares/NStackPreloadMiddleware.swift
+++ b/Sources/NStack/Middlewares/NStackPreloadMiddleware.swift
@@ -12,12 +12,14 @@ public final class NStackPreloadMiddleware: Middleware {
             return try next.respond(to: request)
         }
         
-        return try nstack.application.translate.preloadLocalization(on: request).flatMap { _ in
-            return try next.respond(to: request)
-        }.catchFlatMap { error in
-            try? request.make(NStackLogger.self).log("NStack error: \(error)")
-            return try next.respond(to: request)
-        }
+        return try nstack.application.translate
+            .preloadLocalization(on: request)
+            .catch { error in
+                try? request.make(NStackLogger.self).log("NStack error: \(error)")
+            }
+            .flatMap { _ in
+                return try next.respond(to: request)
+            }
     }
 }
 


### PR DESCRIPTION
- prevents "NStack Error: " logs for all errors
- prevents creating response twice which would cause (among others)
  problems with routing parameters